### PR TITLE
feat: Add Arts Assistant role

### DIFF
--- a/app.py
+++ b/app.py
@@ -381,6 +381,12 @@ def get_financial_advice(prompt):
     # possibly integrating with financial data APIs or a fine-tuned LLM.
     return advice
 
+def generate_art_criticism(prompt):
+    criticism = _("This is a placeholder for an art criticism based on your prompt: %(prompt)s", prompt=prompt)
+    # In a real application, this would connect to a generative AI model
+    # to produce a more meaningful and context-aware art criticism.
+    return criticism
+
 def debug_code(prompt):
     if prompt.strip().startswith('http'):
         code = fetch_github_file(prompt)
@@ -630,6 +636,16 @@ def financial_advice_endpoint():
     if not prompt:
         return jsonify({"error": _("Prompt is required")}), 400
     message = get_financial_advice(prompt)
+    return jsonify({"status": "success", "message": message})
+
+@app.route('/api/v1/art/criticism', methods=['POST'])
+@require_api_key
+def art_criticism_endpoint():
+    data = request.get_json()
+    prompt = data.get('prompt')
+    if not prompt:
+        return jsonify({"error": _("Prompt is required")}), 400
+    message = generate_art_criticism(prompt)
     return jsonify({"status": "success", "message": message})
 
 @app.route('/api/register', methods=['POST'])

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -54,6 +54,10 @@
                     <h3>Banking and Financial Assistant</h3>
                     <p>Our AI can provide financial advice and help you manage your finances.</p>
                 </div>
+                <div class="card">
+                    <h3>Arts Assistant</h3>
+                    <p>Our AI can provide art critiques, generate artistic ideas, and more.</p>
+                </div>
             </div>
         </section>
 


### PR DESCRIPTION
This commit introduces a new 'Arts Assistant' role to the AI agent.

- A new function `generate_art_criticism` and a corresponding API endpoint `/api/v1/art/criticism` have been added to `app.py`. The function currently returns a placeholder response.
- The frontend has been updated in `frontend/templates/index.html` to include a service card for the new Arts Assistant, making it visible to users on the landing page.

## Summary by Sourcery

Introduce a new Arts Assistant role by implementing a placeholder art criticism function and secured API endpoint, and update the frontend to feature the new service on the homepage.

New Features:
- Add generate_art_criticism function to produce art critique responses
- Introduce /api/v1/art/criticism endpoint protected by API key

Enhancements:
- Display Arts Assistant service card on the landing page