### PR TITLE
Migrate Domain to ai.yendoukoa.com and Configure GCP CI/CD

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -1,0 +1,30 @@
+name: Deploy to Google Cloud Run
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  SERVICE_NAME: ai-agent
+  REGION: us-central1
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Google Auth
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      - name: 'Build and Deploy'
+        run: |
+          gcloud builds submit --config cloudbuild.yaml

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-yendoukoa.google.ai
+ai.yendoukoa.com

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Stay productive everywhere with Yendoukoa AI!
 
 This project is a submission for the **[Name of Devpost Challenge]**.
 
-*   **Live Demo:** [https://yendoukoa.google.ai](https://yendoukoa.google.ai)
+*   **Live Demo:** [https://ai.yendoukoa.com](https://ai.yendoukoa.com)
 *   **Video Walkthrough:** [Link to Video Walkthrough]
 
 ## Sponsorship

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-yendoukoa.google.ai
+ai.yendoukoa.com

--- a/extension/index.html
+++ b/extension/index.html
@@ -18,6 +18,6 @@
     </style>
 </head>
 <body>
-    <iframe src="https://yendoukoa.ai"></iframe>
+    <iframe src="https://ai.yendoukoa.com"></iframe>
 </body>
 </html>

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -8,5 +8,5 @@
     "default_icon": "icon.svg"
   },
   "permissions": ["activeTab", "storage"],
-  "host_permissions": ["https://yendoukoa.ai/*"]
+  "host_permissions": ["https://ai.yendoukoa.com/*"]
 }

--- a/google_ai.py
+++ b/google_ai.py
@@ -965,8 +965,8 @@ def provide_maintenance_assistance(prompt: str) -> str:
 def provide_google_sites_assistance(prompt: str) -> str:
     model = get_model()
     prompt_template = ChatPromptTemplate.from_messages([
-        ("system", "You are an expert Google Sites and DNS Specialist."),
-        ("user", "Provide high-level technical guidance for Google Sites, DNS, and custom subdomains for: {prompt}")
+        ("system", "You are an expert Google Sites and DNS Specialist. Our primary domain is ai.yendoukoa.com."),
+        ("user", "Provide high-level technical guidance for Google Sites, DNS, and custom subdomains (especially for ai.yendoukoa.com) for: {prompt}")
     ])
     chain = prompt_template | model | StrOutputParser()
     try:
@@ -1145,8 +1145,8 @@ def provide_mlops_assistance(prompt: str) -> str:
 def provide_cloud_infrastructure_assistance(prompt: str) -> str:
     model = get_model()
     prompt_template = ChatPromptTemplate.from_messages([
-        ("system", "You are an expert Cloud Infrastructure Architect specializing in secure IP addresses, DNS configuration, and cloud server creation (AWS, GCP, Azure)."),
-        ("user", "Provide high-level technical guidance and secure implementation steps for: {prompt}")
+        ("system", "You are an expert Cloud Infrastructure Architect specializing in secure IP addresses, DNS configuration, and cloud server creation (AWS, GCP, Azure). Our primary domain is ai.yendoukoa.com."),
+        ("user", "Provide high-level technical guidance and secure implementation steps (including DNS setup for ai.yendoukoa.com) for: {prompt}")
     ])
     chain = prompt_template | model | StrOutputParser()
     try:

--- a/marketplace-frontend/public/CNAME
+++ b/marketplace-frontend/public/CNAME
@@ -1,1 +1,1 @@
-yendoukoa.google.ai
+ai.yendoukoa.com


### PR DESCRIPTION
This PR migrates the platform's primary domain from yendoukoa.google.ai to ai.yendoukoa.com across all components (frontend, extension, and documentation). Additionally, it establishes a robust CI/CD pipeline by adding a GitHub Action for automated deployment to Google Cloud Run via Cloud Build, ensuring the platform tools are fully integrated with modern cloud infrastructure.

---
*PR created automatically by Jules for task [12055352246504378476](https://jules.google.com/task/12055352246504378476) started by @GYFX35*

## Summary by Sourcery

Update the platform to use ai.yendoukoa.com as the primary domain and add automated deployment to Google Cloud Run via Google Cloud Build.

New Features:
- Add a GitHub Actions workflow to build and deploy the service to Google Cloud Run using Cloud Build.

Enhancements:
- Update system prompts to reference ai.yendoukoa.com for DNS and cloud infrastructure guidance.
- Switch the live demo link and browser extension iframe/host permissions to use ai.yendoukoa.com as the primary domain.

CI:
- Introduce a CI/CD workflow that authenticates to GCP and triggers Cloud Build for deployments to Cloud Run.

Documentation:
- Update README live demo URL to ai.yendoukoa.com.