### PR TITLE
Add Domain Codex Designer AI Role

### DIFF
--- a/app.py
+++ b/app.py
@@ -1517,6 +1517,17 @@ def cloud_infrastructure_assistance_endpoint():
     return jsonify({"status": "success", "message": message})
 
 
+@app.route('/api/v1/domain-codex/assistance', methods=['POST'])
+@require_api_key
+def domain_codex_assistance_endpoint():
+    data = request.get_json()
+    prompt = data.get('prompt')
+    if not prompt:
+        return jsonify({"error": _("Prompt is required")}), 400
+    message = google_ai.provide_domain_codex_assistance(prompt)
+    return jsonify({"status": "success", "message": message})
+
+
 @app.route('/api/v1/llama/intelligence', methods=['POST'])
 @require_api_key
 def llama_intelligence_endpoint():

--- a/frontend/static/js/script.js
+++ b/frontend/static/js/script.js
@@ -261,6 +261,44 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    // --- Domain Codex Assistance ---
+    const domainCodexBtn = document.getElementById('domain-codex-btn');
+    if (domainCodexBtn) {
+        domainCodexBtn.addEventListener('click', async () => {
+            const input = document.getElementById('domain-codex-input');
+            const responseContainer = document.getElementById('domain-codex-response');
+            const apiKey = getApiKey("Please enter your API key to use the Domain Codex Designer:");
+
+            if (!apiKey) {
+                responseContainer.textContent = 'API key is required.';
+                return;
+            }
+
+            try {
+                const response = await fetch('/api/v1/domain-codex/assistance', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-API-Key': apiKey
+                    },
+                    body: JSON.stringify({
+                        prompt: input.value
+                    })
+                });
+
+                if (!response.ok) {
+                    const error = await response.json();
+                    throw new Error(error.error || 'Failed to get a response from the domain codex designer');
+                }
+
+                const result = await response.json();
+                responseContainer.textContent = result.message;
+            } catch (error) {
+                responseContainer.textContent = `Error: ${error.message}`;
+            }
+        });
+    }
+
     // --- Data Science & Stewardship Assistance ---
     const dataScienceStewardshipBtn = document.getElementById('data-science-stewardship-btn');
     if (dataScienceStewardshipBtn) {

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -19,6 +19,7 @@
                 <li><a href="#maintenance-assistance">{{ _('Maintenance') }}</a></li>
                 <li><a href="#it-operations-assistance">{{ _('IT Ops') }}</a></li>
                 <li><a href="#cloud-infrastructure-assistance">{{ _('Cloud Infra') }}</a></li>
+                <li><a href="#domain-codex-assistance">{{ _('Domain Codex') }}</a></li>
                 <li><a href="#esports-assistance">{{ _('eSports') }}</a></li>
                 <li><a href="#fake-content-verification">{{ _('Verification') }}</a></li>
                 <li><a href="#military-assistance">{{ _('Military') }}</a></li>
@@ -252,6 +253,10 @@
                     <p>{{ _('Expert assistance for creating secure IP addresses, DNS configuration, and cloud server creation.') }}</p>
                 </div>
                 <div class="card">
+                    <h3>{{ _('Domain Codex Designer') }}</h3>
+                    <p>{{ _('Elite custom domain design and USSP (U-space Service Provider) infrastructure architect.') }}</p>
+                </div>
+                <div class="card">
                     <h3>{{ _('Llama Intelligence Specialist') }}</h3>
                     <p>{{ _('Deep reasoning and data-driven insights powered by Llama 3.1 405B for complex problem solving.') }}</p>
                 </div>
@@ -274,6 +279,22 @@
                 <div class="card">
                     <h3>{{ _('Claude Coding Specialist') }}</h3>
                     <p>{{ _('Elite code generation and architectural advice powered by Anthropic Claude.') }}</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Domain Codex Designer Section -->
+        <section id="domain-codex-assistance" class="services">
+            <h2>{{ _('Domain Codex Designer') }}</h2>
+            <div class="service-cards">
+                <div class="card">
+                    <h3>{{ _('DHCP, Codex Domain & USSP Support') }}</h3>
+                    <p>{{ _('Enter your request for custom domain design, DHCP configuration, or USSP infrastructure below.') }}</p>
+                    <textarea id="domain-codex-input" placeholder="{{ _('Your domain codex request') }}" class="styled-textarea" rows="4"></textarea>
+                    <button id="domain-codex-btn" class="btn">{{ _('Submit') }}</button>
+                    <div class="response-container" id="domain-codex-response-container">
+                        <pre id="domain-codex-response"></pre>
+                    </div>
                 </div>
             </div>
         </section>

--- a/google_ai.py
+++ b/google_ai.py
@@ -163,6 +163,29 @@ def generate_business_strategy(prompt: str) -> str:
     except Exception as e:
         return f"Error: {e}"
 
+def provide_domain_codex_assistance(prompt: str) -> str:
+    """
+    Expert AI Model for Domain Codex Design, DHCP configuration, and USSP infrastructure.
+    """
+    model = get_model()
+    system_prompt = (
+        "You are an Elite Domain Codex Designer and Infrastructure Architect. "
+        "Your expertise covers custom domain design, DHCP address configuration, "
+        "and USSP (U-space Service Provider) infrastructure using Codex-level insights. "
+        "Provide high-level technical guidance, strategic design plans, and secure "
+        "implementation steps for advanced AI projects requiring specialized network "
+        "architectures and domain naming conventions. Our primary domain is ai.yendoukoa.com."
+    )
+    prompt_template = ChatPromptTemplate.from_messages([
+        ("system", system_prompt),
+        ("user", "{prompt}")
+    ])
+    chain = prompt_template | model | StrOutputParser()
+    try:
+        return chain.invoke({"prompt": prompt}).strip()
+    except Exception as e:
+        return f"Domain Codex AI Error: {e}"
+
 def provide_claude_intelligence(prompt: str) -> str:
     """
     Uses Anthropic Claude for deep reasoning, strategic analysis, and nuanced understanding.

--- a/marketplace-frontend/src/App.tsx
+++ b/marketplace-frontend/src/App.tsx
@@ -87,6 +87,7 @@ const AI_SERVICES: AIService[] = [
   { id: 'investment', name: 'Investment Specialist', category: 'Business', icon: TrendingUp, description: 'Investment optimization and trading assistance.' },
   { id: 'autogpt', name: 'AutoGPT Agent', category: 'Advanced', icon: Bot, description: 'Autonomous agent for multi-step task planning and strategy.' },
   { id: 'cloud-infra', name: 'Cloud Infra Architect', category: 'Infrastructure', icon: Server, description: 'Expert in secure IPs, DNS, and cloud server creation.' },
+  { id: 'domain-codex', name: 'Domain Codex Designer', category: 'Infrastructure', icon: Layout, description: 'Elite custom domain design and USSP infrastructure architect.' },
   { id: 'iaas', name: 'IaaS Specialist', category: 'Infrastructure', icon: Cpu, description: 'Infrastructure as a Service expert for virtualized resources.' },
   { id: 'paas', name: 'PaaS Specialist', category: 'Infrastructure', icon: Cloud, description: 'Platform as a Service expert for application development environments.' },
   { id: 'saas', name: 'SaaS Specialist', category: 'Infrastructure', icon: Globe, description: 'Software as a Service expert for internet-delivered applications.' },
@@ -190,6 +191,9 @@ const App: React.FC = () => {
           break;
         case 'cloud-infra':
           response = await aiService.getCloudInfrastructureAssistance(servicePrompt);
+          break;
+        case 'domain-codex':
+          response = await aiService.getDomainCodexAssistance(servicePrompt);
           break;
         case 'iaas':
           response = await aiService.getIaaSAssistance(servicePrompt);

--- a/marketplace-frontend/src/api.ts
+++ b/marketplace-frontend/src/api.ts
@@ -64,6 +64,7 @@ export const aiService = {
   getAutoMLModelSelection: (prompt: string) => apiClient.post('/automl/model-selection', { prompt }),
   getAutoMLMLOps: (prompt: string) => apiClient.post('/automl/mlops', { prompt }),
   getCloudInfrastructureAssistance: (prompt: string) => apiClient.post('/cloud-infrastructure/assistance', { prompt }),
+  getDomainCodexAssistance: (prompt: string) => apiClient.post('/domain-codex/assistance', { prompt }),
   getMonetizationAdvice: (prompt: string) => apiClient.post('/business/monetization', { prompt }),
   getPartnershipAdvice: (prompt: string) => apiClient.post('/business/partnership', { prompt }),
   getFundraisingAdvice: (prompt: string) => apiClient.post('/business/fundraising', { prompt }),


### PR DESCRIPTION
I have added a new AI role called 'Domain Codex Designer' to the platform. This specialist is designed to help users with DHCP address configuration, custom domain design (Codex domains), and USSP infrastructure architecting for AI projects.

Key updates include:
- A new backend endpoint `/api/v1/domain-codex/assistance`.
- A specialized AI logic using Gemini in `google_ai.py`.
- Full integration into the React-based Marketplace frontend.
- Full integration into the legacy HTML/JavaScript frontend.

---
*PR created automatically by Jules for task [14638947146683442646](https://jules.google.com/task/14638947146683442646) started by @GYFX35*

## Summary by Sourcery

Add a new Domain Codex Designer AI role and expose it across backends and both frontends for domain, DHCP, and USSP infrastructure assistance.

New Features:
- Introduce a Domain Codex Designer AI capability for domain design, DHCP configuration, and USSP infrastructure guidance.
- Expose a secured /api/v1/domain-codex/assistance backend endpoint that returns Domain Codex assistance responses.
- Add Domain Codex Designer cards and interaction flows to both the legacy HTML/JS UI and the React marketplace frontend, including navigation and request handling.

Enhancements:
- Extend the Google AI integration with a specialized Domain Codex assistance handler using the existing Gemini-based pipeline.