### PR TITLE
Update platform domain to yendoukoa.ai

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-ai.yendoukoa.com
+yendoukoa.ai

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Stay productive everywhere with Yendoukoa AI!
 
 This project is a submission for the **[Name of Devpost Challenge]**.
 
-*   **Live Demo:** [https://ai.yendoukoa.com](https://ai.yendoukoa.com)
+*   **Live Demo:** [https://yendoukoa.ai](https://yendoukoa.ai)
 *   **Video Walkthrough:** [Link to Video Walkthrough]
 
 ## Sponsorship

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-ai.yendoukoa.com
+yendoukoa.ai

--- a/extension/index.html
+++ b/extension/index.html
@@ -18,6 +18,6 @@
     </style>
 </head>
 <body>
-    <iframe src="https://ai.yendoukoa.com"></iframe>
+    <iframe src="https://yendoukoa.ai"></iframe>
 </body>
 </html>

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -8,5 +8,5 @@
     "default_icon": "icon.svg"
   },
   "permissions": ["activeTab", "storage"],
-  "host_permissions": ["https://ai.yendoukoa.com/*"]
+  "host_permissions": ["https://yendoukoa.ai/*"]
 }

--- a/google_ai.py
+++ b/google_ai.py
@@ -174,7 +174,7 @@ def provide_domain_codex_assistance(prompt: str) -> str:
         "and USSP (U-space Service Provider) infrastructure using Codex-level insights. "
         "Provide high-level technical guidance, strategic design plans, and secure "
         "implementation steps for advanced AI projects requiring specialized network "
-        "architectures and domain naming conventions. Our primary domain is ai.yendoukoa.com."
+        "architectures and domain naming conventions. Our primary domain is yendoukoa.ai."
     )
     prompt_template = ChatPromptTemplate.from_messages([
         ("system", system_prompt),
@@ -988,8 +988,8 @@ def provide_maintenance_assistance(prompt: str) -> str:
 def provide_google_sites_assistance(prompt: str) -> str:
     model = get_model()
     prompt_template = ChatPromptTemplate.from_messages([
-        ("system", "You are an expert Google Sites and DNS Specialist. Our primary domain is ai.yendoukoa.com."),
-        ("user", "Provide high-level technical guidance for Google Sites, DNS, and custom subdomains (especially for ai.yendoukoa.com) for: {prompt}")
+        ("system", "You are an expert Google Sites and DNS Specialist. Our primary domain is yendoukoa.ai."),
+        ("user", "Provide high-level technical guidance for Google Sites, DNS, and custom subdomains (especially for yendoukoa.ai) for: {prompt}")
     ])
     chain = prompt_template | model | StrOutputParser()
     try:
@@ -1168,8 +1168,8 @@ def provide_mlops_assistance(prompt: str) -> str:
 def provide_cloud_infrastructure_assistance(prompt: str) -> str:
     model = get_model()
     prompt_template = ChatPromptTemplate.from_messages([
-        ("system", "You are an expert Cloud Infrastructure Architect specializing in secure IP addresses, DNS configuration, and cloud server creation (AWS, GCP, Azure). Our primary domain is ai.yendoukoa.com."),
-        ("user", "Provide high-level technical guidance and secure implementation steps (including DNS setup for ai.yendoukoa.com) for: {prompt}")
+        ("system", "You are an expert Cloud Infrastructure Architect specializing in secure IP addresses, DNS configuration, and cloud server creation (AWS, GCP, Azure). Our primary domain is yendoukoa.ai."),
+        ("user", "Provide high-level technical guidance and secure implementation steps (including DNS setup for yendoukoa.ai) for: {prompt}")
     ])
     chain = prompt_template | model | StrOutputParser()
     try:

--- a/marketplace-frontend/public/CNAME
+++ b/marketplace-frontend/public/CNAME
@@ -1,1 +1,1 @@
-ai.yendoukoa.com
+yendoukoa.ai


### PR DESCRIPTION
This change updates the official domain name of the Yendoukoa AI platform from ai.yendoukoa.com to yendoukoa.ai.

Key changes include:
1.  **CNAME Updates**: Modified `CNAME` files in the root, `docs/`, and `marketplace-frontend/public/` to ensure correct DNS routing.
2.  **Documentation**: Updated the live demo link in `README.md`.
3.  **Backend Logic**: Updated system prompts in `google_ai.py` for various AI roles (Cloud Architect, Google Sites Specialist, etc.) to reflect the new primary domain.
4.  **Browser Extension**: Updated `extension/manifest.json` host permissions and `extension/index.html` iframe source to point to the new domain.
5.  **Global Search and Replace**: Ensured no references to the old domain remain in the codebase.

---
*PR created automatically by Jules for task [13161966184021802251](https://jules.google.com/task/13161966184021802251) started by @GYFX35*

## Summary by Sourcery

Update the platform to use yendoukoa.ai as the primary domain across code, extension, and configuration.

Enhancements:
- Align backend system prompts and guidance with the new primary domain yendoukoa.ai.
- Update the browser extension iframe and host permissions to point to yendoukoa.ai instead of the old domain.
- Change project documentation and CNAME configurations to reference and route to yendoukoa.ai.

Documentation:
- Update the README live demo link to the new yendoukoa.ai domain.