### PR TITLE
Split Frontend Static from Flask API for GitHub Pages Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,21 @@ We are excited to announce that Yendoukoa AI is now accessible across all your d
 
 Stay productive everywhere with Yendoukoa AI!
 
+## GitHub Site Web View & Split Architecture
+
+Yendoukoa AI now uses a split architecture to optimize deployment and performance:
+
+1.  **Frontend (Static):** The React-based marketplace frontend is hosted on **GitHub Pages** (the `docs/` directory). This provides a fast, globally distributed "Web View" of the platform.
+2.  **Backend (API):** The Flask-based API is deployed separately (e.g., on Google Cloud Run or AWS).
+
+This split allows for independent scaling and simplifies the deployment of the frontend to GitHub's static hosting.
+
 ## Devpost Challenge Submission
 
 This project is a submission for the **[Name of Devpost Challenge]**.
 
-*   **Live Demo:** [https://yendoukoa.ai](https://yendoukoa.ai)
+*   **Live Demo (Frontend):** [https://yendoukoa.ai](https://yendoukoa.ai)
+*   **API Documentation:** [https://yendoukoa.ai/api/v1](https://yendoukoa.ai/api/v1) (when backend is active)
 *   **Video Walkthrough:** [Link to Video Walkthrough]
 
 ## Sponsorship
@@ -96,18 +106,38 @@ Enter a full website URL (e.g., `https://example.com`) to scan the page for brok
 
 ### Running the Application
 
-1. **Initialize the database:**
-   ```bash
-   flask init-db
-   ```
+#### 1. Backend (Flask API)
 
-2. **Start the server:**
-   ```bash
-   flask run
-   ```
+1.  **Initialize the database:**
+    ```bash
+    flask init-db
+    ```
 
-3. **Open your web browser:**
-   Navigate to `http://127.0.0.1:5000` to access the application.
+2.  **Start the server:**
+    ```bash
+    flask run --port 5001
+    ```
+
+#### 2. Frontend (React Marketplace)
+
+1.  **Navigate to the frontend directory:**
+    ```bash
+    cd marketplace-frontend
+    ```
+
+2.  **Set the API URL (Optional for local dev):**
+    Create a `.env.local` file:
+    ```
+    VITE_API_BASE_URL=http://localhost:5001/api/v1
+    ```
+
+3.  **Start the development server:**
+    ```bash
+    npm run dev
+    ```
+
+4.  **Open your web browser:**
+    Navigate to the URL provided by Vite (usually `http://localhost:5173`).
 
 ## Developer Deployment and Integration
 

--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ import asyncio
 from bs4 import BeautifulSoup
 from urllib.parse import urljoin, urlparse
 from flask import Flask, jsonify, render_template, request, g, session, redirect, url_for
+from flask_cors import CORS
 import secrets
 from functools import wraps
 from flask_sqlalchemy import SQLAlchemy
@@ -66,6 +67,7 @@ class Payment(db.Model):
 
 # --- Flask App Setup ---
 app = Flask(__name__, template_folder='frontend/templates', static_folder='frontend/static')
+CORS(app, resources={r"/api/*": {"origins": ["https://yendoukoa.ai", "http://localhost:5173", "http://localhost:3000"]}}, supports_credentials=True)
 app.config['SECRET_KEY'] = secrets.token_hex(16)
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///project.db'
 app.config['LANGUAGES'] = LANGUAGES

--- a/marketplace-frontend/src/api.ts
+++ b/marketplace-frontend/src/api.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_BASE_URL = '/api/v1';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api/v1';
 
 const apiClient = axios.create({
   baseURL: API_BASE_URL,

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ langchain-nvidia-ai-endpoints
 langflow
 llama-index
 llama-index-llms-nvidia
+flask-cors>=5.0.0


### PR DESCRIPTION
This PR decouples the React frontend from the Flask backend to facilitate hosting the static site on GitHub Pages while keeping the API on an independent server.

Key changes:
- Added `flask-cors` to the backend and configured allowed origins in `app.py`.
- Modified the frontend's API client to use `import.meta.env.VITE_API_BASE_URL` for dynamic endpoint configuration.
- Updated the `README.md` to reflect the new architecture and provide setup/deployment instructions.
- Verified visual integrity of the static build via Playwright.

---
*PR created automatically by Jules for task [11606994164521596957](https://jules.google.com/task/11606994164521596957) started by @GYFX35*

## Summary by Sourcery

Decouple the React frontend from the Flask backend to support static hosting on GitHub Pages while keeping the API on a separate server.

New Features:
- Allow the frontend to configure its API base URL via an environment variable for flexible backend deployment.

Enhancements:
- Enable CORS for the Flask API to permit requests from the GitHub Pages frontend and common local development origins.
- Document the new split frontend/backend architecture, including updated run instructions for both services and links to the live frontend and API docs.

Build:
- Add flask-cors as a backend dependency to support cross-origin requests.