### PR TITLE
Set up PSF and GitHub Sponsorship tools

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
-bitcoin
-github: GYFX35
+
+github: [GYFX35, psf, python]
 patreon: yendoukoa
 open_collective: yendoukoa
 ko_fi: # Replace with a single Ko-fi username
@@ -11,4 +11,4 @@ issuehunt: # Replace with a single IssueHunt username
 lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
 polar: # Replace with a single Polar username
 buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
-custom: ['https://buy.stripe.com/example']
+custom: ['https://buy.stripe.com/example', 'https://www.python.org/psf/donations/']

--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ If you find this project useful, please consider sponsoring us!
 [![Sponsor](https://img.shields.io/badge/Sponsor-Open%20Collective-7f9bff?style=for-the-badge&logo=open-collective)](https://opencollective.com/yendoukoa)
 [![Sponsor](https://img.shields.io/badge/Sponsor-Patreon-f96854?style=for-the-badge&logo=patreon)](https://patreon.com/yendoukoa)
 
+### Python Software Foundation (PSF) Support
+
+We proudly support the Python Software Foundation. If you'd like to fund Python's core development, infrastructure (like PyPI), and global community grants, please consider sponsoring or donating to the PSF directly:
+
+[![Sponsor PSF](https://img.shields.io/badge/Sponsor-Python%20Software%20Foundation-3776AB?style=for-the-badge&logo=python&logoColor=white)](https://github.com/sponsors/psf)
+[![Donate PSF](https://img.shields.io/badge/Donate-PSF%20Donations-3776AB?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/psf/donations/)
+
 ## Features
 
 - **Software Engineer:** Generates multi-section HTML and CSS for a static website.

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -1249,7 +1249,12 @@
 
     <footer id="contact">
         <p>&copy; 2024 Yendoukoa AI. All rights reserved.</p>
-        <p><a href="https://github.com/sponsors/GYFX35" target="_blank">{{ _('Sponsor us on GitHub') }}</a> | <a href="https://buy.stripe.com/example" target="_blank">{{ _('Sponsor us via Stripe') }}</a></p>
+        <p>
+            <a href="https://github.com/sponsors/GYFX35" target="_blank">{{ _('Sponsor us on GitHub') }}</a> |
+            <a href="https://buy.stripe.com/example" target="_blank">{{ _('Sponsor us via Stripe') }}</a> |
+            <a href="https://github.com/sponsors/psf" target="_blank">{{ _('Sponsor PSF on GitHub') }}</a> |
+            <a href="https://www.python.org/psf/donations/" target="_blank">{{ _('Donate to PSF') }}</a>
+        </p>
     </footer>
 
     <script type="text/javascript">

--- a/marketplace-frontend/package.json
+++ b/marketplace-frontend/package.json
@@ -2,6 +2,20 @@
   "name": "marketplace-frontend",
   "private": true,
   "version": "2.0.0",
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/GYFX35"
+    },
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/psf"
+    },
+    {
+      "type": "custom",
+      "url": "https://www.python.org/psf/donations/"
+    }
+  ],
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/setup.py
+++ b/setup.py
@@ -83,5 +83,11 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
+    project_urls={
+        "Funding": "https://github.com/sponsors/GYFX35",
+        "PSF Sponsors": "https://github.com/sponsors/psf",
+        "PSF Donations": "https://www.python.org/psf/donations/",
+        "Source": "https://github.com/GYFX35/AI-services",
+    },
     python_requires='>=3.6',
 )


### PR DESCRIPTION
This patch sets up GitHub sponsorship and the Python Software Foundation (PSF) funding options within .github/FUNDING.yml, setup.py project_urls, marketplace-frontend/package.json funding, README.md sponsorship badges, and the main frontend footer.

---
*PR created automatically by Jules for task [4895883398284061840](https://jules.google.com/task/4895883398284061840) started by @GYFX35*

## Summary by Sourcery

Add PSF and GitHub sponsorship links across funding configuration, documentation, and UI to highlight and support both the project and the Python Software Foundation.

New Features:
- Expose multiple sponsorship and donation options (project, PSF, and Python) via npm funding metadata in marketplace-frontend.
- Add PSF sponsorship and donation section to the README with badges linking to GitHub Sponsors and PSF donations.
- Extend the main frontend footer with links for sponsoring and donating to the PSF alongside existing project funding options.

Enhancements:
- Expand .github/FUNDING.yml to include PSF and Python GitHub sponsors and PSF donation URL in custom funding links.
- Add project and PSF funding URLs to setup.py project_urls to surface sponsorship information in package metadata.